### PR TITLE
Check that user-provided options are zeroed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         run: bash <(curl -s https://codecov.io/bash) -f coverage.lcov -y .github/codecov.yml
 
   ci_windows:
-    runs-on: windows-latest
+    runs-on: windows-2019
     steps:
       - uses: actions/checkout@v2
       - name: Run tests

--- a/ufbx.c
+++ b/ufbx.c
@@ -1257,6 +1257,8 @@ static void ufbxi_fix_error_type(ufbx_error *error, const char *default_desc)
 		error->type = UFBX_ERROR_NOT_FBX;
 	} else if (!strcmp(error->description, "File not found")) {
 		error->type = UFBX_ERROR_FILE_NOT_FOUND;
+	} else if (!strcmp(error->description, "Uninitialized options")) {
+		error->type = UFBX_ERROR_FILE_NOT_FOUND;
 	}
 }
 
@@ -12454,6 +12456,8 @@ typedef struct {
 	ufbx_string filename;
 	bool owned_by_scene;
 
+	ufbx_geometry_cache_opts opts;
+
 	ufbxi_allocator *ator_tmp;
 	ufbxi_allocator ator_result;
 
@@ -13082,6 +13086,10 @@ static ufbxi_noinline int ufbxi_cache_setup_channels(ufbxi_cache_context *cc)
 
 static ufbxi_noinline int ufbxi_cache_load_imp(ufbxi_cache_context *cc, ufbx_string filename)
 {
+	// `ufbx_geometry_cache_opts` must be cleared to zero first!
+	ufbx_assert(cc->opts._begin_zero == 0 && cc->opts._end_zero == 0);
+	ufbxi_check_err_msg(&cc->error, cc->opts._begin_zero == 0 && cc->opts._end_zero == 0, "Uninitialized options");
+
 	cc->tmp.ator = cc->ator_tmp;
 	cc->tmp_stack.ator = cc->ator_tmp;
 
@@ -13172,6 +13180,8 @@ ufbxi_noinline static ufbx_geometry_cache *ufbxi_load_geometry_cache(ufbx_string
 	ufbxi_init_ator(&cc.error, &ator_tmp, &opts.temp_allocator);
 	ufbxi_init_ator(&cc.error, &cc.ator_result, &opts.result_allocator);
 	cc.ator_tmp = &ator_tmp;
+
+	cc.opts = opts;
 
 	cc.open_file_fn = opts.open_file_fn;
 	cc.open_file_user = opts.open_file_user;
@@ -13473,6 +13483,10 @@ ufbxi_nodiscard static int ufbxi_evaluate_skinning(ufbx_scene *scene, ufbx_error
 
 ufbxi_nodiscard static int ufbxi_load_imp(ufbxi_context *uc)
 {
+	// `ufbx_load_opts` must be cleared to zero first!
+	ufbx_assert(uc->opts._begin_zero == 0 && uc->opts._end_zero == 0);
+	ufbxi_check_msg(uc->opts._begin_zero == 0 && uc->opts._end_zero == 0, "Uninitialized options");
+
 	ufbxi_check(ufbxi_load_strings(uc));
 	ufbxi_check(ufbxi_load_maps(uc));
 	ufbxi_check(ufbxi_begin_parse(uc));
@@ -14104,6 +14118,10 @@ ufbxi_nodiscard static int ufbxi_translate_anim(ufbxi_eval_context *ec, ufbx_ani
 
 ufbxi_nodiscard static int ufbxi_evaluate_imp(ufbxi_eval_context *ec)
 {
+	// `ufbx_evaluate_opts` must be cleared to zero first!
+	ufbx_assert(ec->opts._begin_zero == 0 && ec->opts._end_zero == 0);
+	ufbxi_check_err_msg(&ec->error, ec->opts._begin_zero == 0 && ec->opts._end_zero == 0, "Uninitialized options");
+
 	ec->scene = ec->src_scene;
 	size_t num_elements = ec->scene.elements.count;
 
@@ -14654,6 +14672,10 @@ ufbxi_nodiscard static ufbxi_noinline int ufbxi_finalize_mesh(ufbxi_buf *buf, uf
 
 ufbxi_nodiscard static ufbxi_noinline int ufbxi_tessellate_nurbs_surface_imp(ufbxi_tessellate_context *tc)
 {
+	// `ufbx_tessellate_opts` must be cleared to zero first!
+	ufbx_assert(tc->opts._begin_zero == 0 && tc->opts._end_zero == 0);
+	ufbxi_check_err_msg(&tc->error, tc->opts._begin_zero == 0 && tc->opts._end_zero == 0, "Uninitialized options");
+
 	if (tc->opts.span_subdivision_u <= 0) {
 		tc->opts.span_subdivision_u = 4;
 	}
@@ -16040,6 +16062,10 @@ ufbxi_nodiscard static ufbxi_noinline int ufbxi_subdivide_mesh_level(ufbxi_subdi
 
 ufbxi_nodiscard static ufbxi_noinline int ufbxi_subdivide_mesh_imp(ufbxi_subdivide_context *sc, size_t level)
 {
+	// `ufbx_subdivide_opts` must be cleared to zero first!
+	ufbx_assert(sc->opts._begin_zero == 0 && sc->opts._end_zero == 0);
+	ufbxi_check_err_msg(&sc->error, sc->opts._begin_zero == 0 && sc->opts._end_zero == 0, "Uninitialized options");
+
 	if (sc->opts.boundary == UFBX_SUBDIVISION_BOUNDARY_DEFAULT) {
 		sc->opts.boundary = sc->src_mesh.subdivision_boundary;
 	}
@@ -18005,6 +18031,10 @@ ufbxi_noinline size_t ufbx_read_geometry_cache_real(const ufbx_cache_frame *fram
 		opts.open_file_fn = ufbx_open_file;
 	}
 
+	// `ufbx_geometry_cache_data_opts` must be cleared to zero first!
+	ufbx_assert(opts._begin_zero == 0 && opts._end_zero == 0);
+	if (!(opts._begin_zero == 0 && opts._end_zero == 0)) return 0;
+
 	bool use_double = false;
 
 	size_t src_count = 0;
@@ -18170,6 +18200,10 @@ ufbxi_noinline size_t ufbx_sample_geometry_cache_real(const ufbx_cache_channel *
 	} else {
 		memset(&opts, 0, sizeof(opts));
 	}
+
+	// `ufbx_geometry_cache_data_opts` must be cleared to zero first!
+	ufbx_assert(opts._begin_zero == 0 && opts._end_zero == 0);
+	if (!(opts._begin_zero == 0 && opts._end_zero == 0)) return 0;
 
 	size_t begin = 0;
 	size_t end = channel->frames.count;

--- a/ufbx.h
+++ b/ufbx.h
@@ -2593,6 +2593,7 @@ typedef enum ufbx_error_type {
 	UFBX_ERROR_CANCELLED,
 	UFBX_ERROR_UNSUPPORTED_VERSION,
 	UFBX_ERROR_NOT_FBX,
+	UFBX_ERROR_UNINITIALIZED_OPTIONS,
 } ufbx_error_type;
 
 // Error description with detailed stack trace
@@ -2656,7 +2657,11 @@ struct ufbx_inflate_retain {
 
 // -- Main API
 
+// Options for `ufbx_load_file/memory/stream/stdio()`
+// NOTE: Initialize to zero with `{ 0 }` (C) or `{ }` (C++)
 typedef struct ufbx_load_opts {
+	uint32_t _begin_zero; 
+
 	ufbx_allocator temp_allocator;   // < Allocator used during loading
 	ufbx_allocator result_allocator; // < Allocator used for the final scene
 
@@ -2722,9 +2727,13 @@ typedef struct ufbx_load_opts {
 	bool use_root_transform;
 	ufbx_transform root_transform;
 
+	uint32_t _end_zero; 
 } ufbx_load_opts;
 
+// Options for `ufbx_evaluate_scene()`
+// NOTE: Initialize to zero with `{ 0 }` (C) or `{ }` (C++)
 typedef struct ufbx_evaluate_opts {
+	uint32_t _begin_zero;
 
 	ufbx_allocator temp_allocator;   // < Allocator used during evaluation
 	ufbx_allocator result_allocator; // < Allocator used for the final scene
@@ -2739,9 +2748,14 @@ typedef struct ufbx_evaluate_opts {
 	ufbx_open_file_fn *open_file_fn;
 	void *open_file_user;
 
+	uint32_t _end_zero;
 } ufbx_evaluate_opts;
 
+// Options for `ufbx_tessellate_nurbs_surface()`
+// NOTE: Initialize to zero with `{ 0 }` (C) or `{ }` (C++)
 typedef struct ufbx_tessellate_opts {
+	uint32_t _begin_zero;
+
 	ufbx_allocator temp_allocator;   // < Allocator used during tessellation
 	ufbx_allocator result_allocator; // < Allocator used for the final mesh
 
@@ -2753,9 +2767,13 @@ typedef struct ufbx_tessellate_opts {
 	int32_t span_subdivision_u;
 	int32_t span_subdivision_v;
 
+	uint32_t _end_zero;
 } ufbx_tessellate_opts;
 
+// Options for `ufbx_subdivide_mesh()`
+// NOTE: Initialize to zero with `{ 0 }` (C) or `{ }` (C++)
 typedef struct ufbx_subdivide_opts {
+	uint32_t _begin_zero;
 
 	ufbx_allocator temp_allocator;   // < Allocator used during subdivision
 	ufbx_allocator result_allocator; // < Allocator used for the final mesh
@@ -2773,9 +2791,13 @@ typedef struct ufbx_subdivide_opts {
 	// Subdivide also tangent attributes
 	bool interpolate_tangents;
 
+	uint32_t _end_zero;
 } ufbx_subdivide_opts;
 
+// Options for `ufbx_load_geometry_cache()`
+// NOTE: Initialize to zero with `{ 0 }` (C) or `{ }` (C++)
 typedef struct ufbx_geometry_cache_opts {
+	uint32_t _begin_zero;
 
 	ufbx_allocator temp_allocator;   // < Allocator used during loading
 	ufbx_allocator result_allocator; // < Allocator used for the final scene
@@ -2787,9 +2809,13 @@ typedef struct ufbx_geometry_cache_opts {
 	// FPS value for converting frame times to seconds
 	double frames_per_second;
 
+	uint32_t _end_zero;
 } ufbx_geometry_cache_opts;
 
+// Options for `ufbx_read_geometry_cache_*()`
+// NOTE: Initialize to zero with `{ 0 }` (C) or `{ }` (C++)
 typedef struct ufbx_geometry_cache_data_opts {
+	uint32_t _begin_zero;
 
 	// External file callbacks (defaults to stdio.h)
 	ufbx_open_file_fn *open_file_fn;
@@ -2799,6 +2825,7 @@ typedef struct ufbx_geometry_cache_data_opts {
 	bool use_weight;
 	ufbx_real weight;
 
+	uint32_t _end_zero;
 } ufbx_geometry_cache_data_opts;
 
 // -- API


### PR DESCRIPTION
Instead of crashing in some obscure place make sure that non-zeroed options provided by the user assert and fail consistently.