### PR TITLE
Axis conversion

### DIFF
--- a/examples/viewer/viewer.c
+++ b/examples/viewer/viewer.c
@@ -724,6 +724,12 @@ void load_scene(viewer_scene *vs, const char *filename)
 		// The viewer contains a proper implementation of skinning as well.
 		// You probably don't need this.
 		.evaluate_skinning = true,
+
+		.transform_to_axes = {
+			.right = UFBX_COORDINATE_AXIS_POSITIVE_X,
+			.up = UFBX_COORDINATE_AXIS_POSITIVE_Y,
+			.front = UFBX_COORDINATE_AXIS_POSITIVE_Z,
+		},
 	};
 	ufbx_error error;
 	ufbx_scene *scene = ufbx_load_file(filename, &opts, &error);
@@ -917,14 +923,17 @@ void frame(void)
 	float dt = (float)stm_sec(stm_laptime(&last_time));
 	dt = um_min(dt, 0.1f);
 
-	g_viewer.anim_time += dt;
-	viewer_anim *anim = &g_viewer.scene.animations[0];
-	if (g_viewer.anim_time >= anim->time_end) {
-		g_viewer.anim_time -= anim->time_end - anim->time_begin;
+	viewer_anim *anim = g_viewer.scene.num_animations > 0 ? &g_viewer.scene.animations[0] : NULL;
+
+	if (anim) {
+		g_viewer.anim_time += dt;
+		if (g_viewer.anim_time >= anim->time_end) {
+			g_viewer.anim_time -= anim->time_end - anim->time_begin;
+		}
+		update_animation(&g_viewer.scene, anim, g_viewer.anim_time);
 	}
 
 	update_camera(&g_viewer);
-	update_animation(&g_viewer.scene, anim, g_viewer.anim_time);
 	update_hierarchy(&g_viewer.scene);
 
 	sg_pass_action action = {

--- a/test/runner.c
+++ b/test/runner.c
@@ -732,6 +732,14 @@ static void ufbxt_assert_close_quat(ufbxt_diff_error *p_err, ufbx_quat a, ufbx_q
 	ufbxt_assert_close_real(p_err, a.w, b.w);
 }
 
+static void ufbxt_assert_close_matrix(ufbxt_diff_error *p_err, ufbx_matrix a, ufbx_matrix b)
+{
+	ufbxt_assert_close_vec3(p_err, a.cols[0], b.cols[0]);
+	ufbxt_assert_close_vec3(p_err, a.cols[1], b.cols[1]);
+	ufbxt_assert_close_vec3(p_err, a.cols[2], b.cols[2]);
+	ufbxt_assert_close_vec3(p_err, a.cols[3], b.cols[3]);
+}
+
 typedef struct {
 	ufbx_vec3 pos;
 	ufbx_vec3 normal;

--- a/test/test_parse.h
+++ b/test/test_parse.h
@@ -64,9 +64,9 @@ UFBXT_FILE_TEST(maya_node_attribute_zoo)
 {
 	ufbx_node *node;
 
-	ufbxt_assert(scene->settings.axis_right == UFBX_COORDINATE_AXIS_POSITIVE_X);
-	ufbxt_assert(scene->settings.axis_up == UFBX_COORDINATE_AXIS_POSITIVE_Y);
-	ufbxt_assert(scene->settings.axis_front == UFBX_COORDINATE_AXIS_POSITIVE_Z);
+	ufbxt_assert(scene->settings.axes.right == UFBX_COORDINATE_AXIS_POSITIVE_X);
+	ufbxt_assert(scene->settings.axes.up == UFBX_COORDINATE_AXIS_POSITIVE_Y);
+	ufbxt_assert(scene->settings.axes.front == UFBX_COORDINATE_AXIS_POSITIVE_Z);
 	ufbxt_assert(scene->settings.time_mode == UFBX_TIME_MODE_24_FPS);
 	ufbxt_assert_close_real(err, scene->settings.unit_scale_factor, 1.0f);
 	ufbxt_assert_close_real(err, scene->settings.frames_per_second, 24.0f);

--- a/ufbx.c
+++ b/ufbx.c
@@ -8903,8 +8903,10 @@ ufbxi_nodiscard static int ufbxi_read_root(ufbxi_context *uc)
 
 		if (uc->opts.use_root_transform) {
 			root->local_transform = uc->opts.root_transform;
+			root->node_to_parent = ufbx_transform_to_matrix(&uc->opts.root_transform);
 		} else {
 			root->local_transform = ufbx_identity_transform;
+			root->node_to_parent = ufbx_identity_matrix;
 		}
 		root->is_root = true;
 	}
@@ -11834,10 +11836,9 @@ ufbxi_noinline static void ufbxi_update_node(ufbx_node *node)
 	node->inherit_type = (ufbx_inherit_type)ufbxi_find_enum(&node->props, ufbxi_InheritType, UFBX_INHERIT_NORMAL, UFBX_INHERIT_NO_SCALE);
 	if (!node->is_root) {
 		node->local_transform = ufbxi_get_transform(&node->props, node->rotation_order);
+		node->geometry_transform = ufbxi_get_geometry_transform(&node->props);
+		node->node_to_parent = ufbx_transform_to_matrix(&node->local_transform); 
 	}
-	node->geometry_transform = ufbxi_get_geometry_transform(&node->props);
-
-	node->node_to_parent = ufbx_transform_to_matrix(&node->local_transform); 
 
 	ufbx_node *parent = node->parent;
 	if (parent) {
@@ -11858,7 +11859,7 @@ ufbxi_noinline static void ufbxi_update_node(ufbx_node *node)
 		}
 	} else {
 		node->world_transform = node->local_transform;
-		node->node_to_world = ufbx_transform_to_matrix(&node->world_transform);
+		node->node_to_world = node->node_to_parent;
 	}
 
 	if (!ufbxi_is_transform_identity(node->geometry_transform)) {
@@ -12391,9 +12392,9 @@ static ufbxi_noinline void ufbxi_update_scene_metadata(ufbx_metadata *metadata)
 
 static ufbxi_noinline void ufbxi_update_scene_settings(ufbx_scene_settings *settings)
 {
-	settings->axis_up = ufbxi_find_axis(&settings->props, ufbxi_UpAxis, ufbxi_UpAxisSign);
-	settings->axis_front = ufbxi_find_axis(&settings->props, ufbxi_FrontAxis, ufbxi_FrontAxisSign);
-	settings->axis_right = ufbxi_find_axis(&settings->props, ufbxi_CoordAxis, ufbxi_CoordAxisSign);
+	settings->axes.up = ufbxi_find_axis(&settings->props, ufbxi_UpAxis, ufbxi_UpAxisSign);
+	settings->axes.front = ufbxi_find_axis(&settings->props, ufbxi_FrontAxis, ufbxi_FrontAxisSign);
+	settings->axes.right = ufbxi_find_axis(&settings->props, ufbxi_CoordAxis, ufbxi_CoordAxisSign);
 	settings->original_axis_up = ufbxi_find_axis(&settings->props, ufbxi_OriginalUpAxis, ufbxi_OriginalUpAxisSign);
 	settings->unit_scale_factor = ufbxi_find_real(&settings->props, ufbxi_UnitScaleFactor, 1.0f);
 	settings->original_unit_scale_factor = ufbxi_find_real(&settings->props, ufbxi_OriginalUnitScaleFactor, settings->unit_scale_factor);
@@ -13338,6 +13339,35 @@ ufbxi_nodiscard static ufbxi_noinline int ufbxi_load_external_files(ufbxi_contex
 	return 1;
 }
 
+static ufbxi_noinline void ufbxi_transform_to_axes(ufbxi_context *uc, ufbx_coordinate_axes dst_axes)
+{
+	if (!ufbx_coordinate_axes_valid(uc->scene.settings.axes)) return;
+	ufbx_coordinate_axes src_axes = uc->scene.settings.axes;
+
+	uint32_t src_x = (uint32_t)src_axes.right;
+	uint32_t dst_x = (uint32_t)dst_axes.right;
+	uint32_t src_y = (uint32_t)src_axes.up;
+	uint32_t dst_y = (uint32_t)dst_axes.up;
+	uint32_t src_z = (uint32_t)src_axes.front;
+	uint32_t dst_z = (uint32_t)dst_axes.front;
+
+	if (src_x == dst_x && src_y == dst_y && src_z == dst_z) return;
+
+	ufbx_matrix axis_mat = { 0 };
+
+	axis_mat.cols[src_x >> 1].v[dst_x >> 1] = ((src_x ^ dst_x) & 1) == 0 ? 1.0f : -1.0f;
+	axis_mat.cols[src_y >> 1].v[dst_y >> 1] = ((src_y ^ dst_y) & 1) == 0 ? 1.0f : -1.0f;
+	axis_mat.cols[src_z >> 1].v[dst_z >> 1] = ((src_z ^ dst_z) & 1) == 0 ? 1.0f : -1.0f;
+
+	if (!ufbxi_is_transform_identity(uc->scene.root_node->local_transform)) {
+		ufbx_matrix root_mat = ufbx_transform_to_matrix(&uc->scene.root_node->local_transform);
+		axis_mat = ufbx_matrix_mul(&axis_mat, &root_mat);
+	}
+
+	uc->scene.root_node->local_transform = ufbx_matrix_to_transform(&axis_mat);
+	uc->scene.root_node->node_to_parent = axis_mat;
+}
+
 // -- Curve evaluation
 
 static ufbxi_forceinline double ufbxi_find_cubic_bezier_t(double p1, double p2, double x0)
@@ -13500,8 +13530,14 @@ ufbxi_nodiscard static int ufbxi_load_imp(ufbxi_context *uc)
 	ufbxi_check(ufbxi_init_file_paths(uc));
 	ufbxi_check(ufbxi_finalize_scene(uc));
 
-	ufbxi_update_scene(&uc->scene, true);
 	ufbxi_update_scene_settings(&uc->scene.settings);
+
+	// Axis conversion
+	if (ufbx_coordinate_axes_valid(uc->opts.transform_to_axes)) {
+		ufbxi_transform_to_axes(uc, uc->opts.transform_to_axes);
+	}
+
+	ufbxi_update_scene(&uc->scene, true);
 
 	if (uc->opts.load_external_files) {
 		ufbxi_check(ufbxi_load_external_files(uc));
@@ -16983,6 +17019,20 @@ ufbx_string ufbx_find_shader_prop_len(const ufbx_shader *shader, const char *nam
 	return name_str;
 }
 
+bool ufbx_coordinate_axes_valid(ufbx_coordinate_axes axes)
+{
+	if (axes.right < UFBX_COORDINATE_AXIS_POSITIVE_X || axes.right > UFBX_COORDINATE_AXIS_NEGATIVE_Z) return false;
+	if (axes.up < UFBX_COORDINATE_AXIS_POSITIVE_X || axes.up > UFBX_COORDINATE_AXIS_NEGATIVE_Z) return false;
+	if (axes.front < UFBX_COORDINATE_AXIS_POSITIVE_X || axes.front > UFBX_COORDINATE_AXIS_NEGATIVE_Z) return false;
+
+	// Check that all the positive/negative axes are used
+	uint32_t mask = 0;
+	mask |= 1u << ((uint32_t)axes.right >> 1);
+	mask |= 1u << ((uint32_t)axes.up >> 1);
+	mask |= 1u << ((uint32_t)axes.front >> 1);
+	return (mask & 0x7u) == 0x7u;
+}
+
 ufbx_quat ufbx_quat_mul(ufbx_quat a, ufbx_quat b)
 {
 	return ufbxi_mul_quat(a, b);
@@ -17254,11 +17304,16 @@ ufbx_matrix ufbx_matrix_mul(const ufbx_matrix *a, const ufbx_matrix *b)
 	return dst;
 }
 
-ufbx_matrix ufbx_matrix_invert(const ufbx_matrix *m)
+ufbx_real ufbx_matrix_determinant(const ufbx_matrix *m)
 {
-	ufbx_real det = 
+	return
 		- m->m02*m->m11*m->m20 + m->m01*m->m12*m->m20 + m->m02*m->m10*m->m21
 		- m->m00*m->m12*m->m21 - m->m01*m->m10*m->m22 + m->m00*m->m11*m->m22;
+}
+
+ufbx_matrix ufbx_matrix_invert(const ufbx_matrix *m)
+{
+	ufbx_real det = ufbx_matrix_determinant(m);
 
 	ufbx_matrix r;
 	if (det == 0.0) {
@@ -17286,9 +17341,7 @@ ufbx_matrix ufbx_matrix_invert(const ufbx_matrix *m)
 
 ufbx_matrix ufbx_matrix_for_normals(const ufbx_matrix *m)
 {
-	ufbx_real det = 
-		- m->m02*m->m11*m->m20 + m->m01*m->m12*m->m20 + m->m02*m->m10*m->m21
-		- m->m00*m->m12*m->m21 - m->m01*m->m10*m->m22 + m->m00*m->m11*m->m22;
+	ufbx_real det = ufbx_matrix_determinant(m);
 
 	ufbx_matrix r;
 	if (det == 0.0) {
@@ -17355,16 +17408,27 @@ ufbx_matrix ufbx_transform_to_matrix(const ufbx_transform *t)
 
 ufbx_transform ufbx_matrix_to_transform(const ufbx_matrix *m)
 {
+	ufbx_real det = ufbx_matrix_determinant(m);
+
 	ufbx_transform t;
 	t.translation = m->cols[3];
 	t.scale.x = ufbxi_length3(m->cols[0]);
 	t.scale.y = ufbxi_length3(m->cols[1]);
 	t.scale.z = ufbxi_length3(m->cols[2]);
 
+	ufbx_real sign_x = 1.0f;
+	ufbx_real sign_y = 1.0f;
+	ufbx_real sign_z = 1.0f;
+	if (det < 0.0f) {
+		if (t.scale.x > 0.0f) sign_x = -1.0f;
+		else if (t.scale.y > 0.0f) sign_y = -1.0f;
+		else if (t.scale.z > 0.0f) sign_z = -1.0f;
+	}
+
 	// TODO: Mirroring?
-	ufbx_vec3 x = ufbxi_mul3(m->cols[0], t.scale.x > 0.0f ? 1.0f / t.scale.x : 0.0f);
-	ufbx_vec3 y = ufbxi_mul3(m->cols[1], t.scale.y > 0.0f ? 1.0f / t.scale.y : 0.0f);
-	ufbx_vec3 z = ufbxi_mul3(m->cols[2], t.scale.z > 0.0f ? 1.0f / t.scale.z : 0.0f);
+	ufbx_vec3 x = ufbxi_mul3(m->cols[0], t.scale.x > 0.0f ? sign_x / t.scale.x : 0.0f);
+	ufbx_vec3 y = ufbxi_mul3(m->cols[1], t.scale.y > 0.0f ? sign_y / t.scale.y : 0.0f);
+	ufbx_vec3 z = ufbxi_mul3(m->cols[2], t.scale.z > 0.0f ? sign_z / t.scale.z : 0.0f);
 	ufbx_real trace = x.x + y.y + z.z;
 	if (trace > 0.0f) {
 		ufbx_real a = (ufbx_real)sqrt(fmax(0.0, trace + 1.0)), b = (a != 0.0f) ? 0.5f / a : 0.0f;
@@ -17405,6 +17469,10 @@ ufbx_transform ufbx_matrix_to_transform(const ufbx_matrix *m)
 			t.rotation.w /= len;
 		}
 	}
+
+	t.scale.x *= sign_x;
+	t.scale.y *= sign_y;
+	t.scale.z *= sign_z;
 
 	return t;
 }

--- a/ufbx.h
+++ b/ufbx.h
@@ -2307,6 +2307,14 @@ typedef enum ufbx_coordinate_axis {
 	UFBX_COORDINATE_AXIS_UNKNOWN,
 } ufbx_coordinate_axis;
 
+// Coordinate axes the scene is represented in.
+// NOTE: `front` is the _opposite_ from forward!
+typedef struct ufbx_coordinate_axes {
+	ufbx_coordinate_axis right;
+	ufbx_coordinate_axis up;
+	ufbx_coordinate_axis front;
+} ufbx_coordinate_axes;
+
 typedef enum ufbx_time_mode {
 	UFBX_TIME_MODE_DEFAULT,
 	UFBX_TIME_MODE_120_FPS,
@@ -2345,9 +2353,7 @@ typedef enum ufbx_snap_mode {
 typedef struct ufbx_scene_settings {
 	ufbx_props props;
 
-	ufbx_coordinate_axis axis_right;
-	ufbx_coordinate_axis axis_up;
-	ufbx_coordinate_axis axis_front;
+	ufbx_coordinate_axes axes;
 
 	ufbx_real unit_scale_factor;
 	double frames_per_second;
@@ -2723,6 +2729,10 @@ typedef struct ufbx_load_opts {
 	ufbx_open_file_fn *open_file_fn;
 	void *open_file_user;
 
+	// Apply an implicit root transformation to match axes.
+	// Used if `ufbx_coordinate_axes_valid(transform_to_axes)`.
+	ufbx_coordinate_axes transform_to_axes;
+
 	// Override for the root transform
 	bool use_root_transform;
 	ufbx_transform root_transform;
@@ -2994,6 +3004,8 @@ ufbx_inline ufbx_string ufbx_find_shader_prop(const ufbx_shader *shader, const c
 
 // Math
 
+bool ufbx_coordinate_axes_valid(ufbx_coordinate_axes axes);
+
 ufbx_quat ufbx_quat_mul(ufbx_quat a, ufbx_quat b);
 ufbx_quat ufbx_quat_normalize(ufbx_quat q);
 ufbx_quat ufbx_quat_fix_antipodal(ufbx_quat q, ufbx_quat reference);
@@ -3003,6 +3015,7 @@ ufbx_vec3 ufbx_quat_to_euler(ufbx_quat q, ufbx_rotation_order order);
 ufbx_quat ufbx_euler_to_quat(ufbx_vec3 v, ufbx_rotation_order order);
 
 ufbx_matrix ufbx_matrix_mul(const ufbx_matrix *a, const ufbx_matrix *b);
+ufbx_real ufbx_matrix_determinant(const ufbx_matrix *m);
 ufbx_matrix ufbx_matrix_invert(const ufbx_matrix *m);
 ufbx_matrix ufbx_matrix_for_normals(const ufbx_matrix *m);
 ufbx_vec3 ufbx_transform_position(const ufbx_matrix *m, ufbx_vec3 v);


### PR DESCRIPTION
Add `ufbx_load_opts.transform_to_axes` to allow specifying target axis system to convert to.

```c
// For standard right-handed Y up
ufbx_load_opts opts = {
    .transform_to_axes = {
        .right = UFBX_COORDINATE_AXIS_POSITIVE_X,
        .up = UFBX_COORDINATE_AXIS_POSITIVE_Y,
        .front = UFBX_COORDINATE_AXIS_POSITIVE_Z,
    },
};
```