### PR TITLE
Tests: Add `ufbxt_file_iterator` to abstract iterating over different file formats

### DIFF
--- a/test/test_material.h
+++ b/test/test_material.h
@@ -60,22 +60,14 @@ UFBXT_FILE_TEST(maya_textured_cube)
 UFBXT_TEST(ignore_embedded)
 #if UFBXT_IMPL
 {
-	const char *name = "maya_textured_cube";
+	char path[512];
 
-	char buf[512];
-	for (uint32_t vi = 0; vi < ufbxt_arraycount(ufbxt_file_versions); vi++) {
-		for (uint32_t fi = 0; fi < 2; fi++) {
-			uint32_t version = ufbxt_file_versions[vi];
-			const char *format = fi == 1 ? "ascii" : "binary";
-			snprintf(buf, sizeof(buf), "%s%s_%u_%s.fbx", data_root, name, version, format);
-		}
-
-		ufbx_error error;
+	ufbxt_file_iterator iter = { "maya_textured_cube" };
+	while (ufbxt_next_file(&iter, path, sizeof(path))) {
 		ufbx_load_opts opts = { 0 };
 		opts.ignore_embedded = true;
-		ufbx_scene *scene = ufbx_load_file(buf, &opts, &error);
-		if (error.type == UFBX_ERROR_FILE_NOT_FOUND) continue;
 
+		ufbx_scene *scene = ufbx_load_file(path, &opts, NULL);
 		ufbxt_assert(scene);
 		ufbxt_check_scene(scene);
 		

--- a/test/test_parse.h
+++ b/test/test_parse.h
@@ -317,3 +317,18 @@ UFBXT_TEST(open_file)
 
 }
 #endif
+
+UFBXT_TEST(file_not_found)
+#if UFBXT_IMPL
+{
+	const char *name = "maya_cube_9999_emoji.fbx";
+
+	char buf[512];
+	snprintf(buf, sizeof(buf), "%s%s", data_root, name);
+
+	ufbx_error error;
+	ufbx_scene *scene = ufbx_load_file(buf, NULL, &error);
+	ufbxt_assert(!scene);
+	ufbxt_assert(error.type == UFBX_ERROR_FILE_NOT_FOUND);
+}
+#endif

--- a/test/test_skin.h
+++ b/test/test_skin.h
@@ -448,24 +448,14 @@ UFBXT_FILE_TEST(synthetic_broken_cluster)
 UFBXT_TEST(synthetic_broken_cluster_connect)
 #if UFBXT_IMPL
 {
-	const char *name = "synthetic_broken_cluster";
-	bool any_found = false;
+	char path[512];
 
-	char buf[512];
-	for (uint32_t vi = 0; vi < ufbxt_arraycount(ufbxt_file_versions); vi++) {
-		for (uint32_t fi = 0; fi < 2; fi++) {
-			uint32_t version = ufbxt_file_versions[vi];
-			const char *format = fi == 1 ? "ascii" : "binary";
-			snprintf(buf, sizeof(buf), "%s%s_%u_%s.fbx", data_root, name, version, format);
-		}
-
-		ufbx_error error;
+	ufbxt_file_iterator iter = { "synthetic_broken_cluster" };
+	while (ufbxt_next_file(&iter, path, sizeof(path))) {
 		ufbx_load_opts opts = { 0 };
 		opts.connect_broken_elements = true;
-		ufbx_scene *scene = ufbx_load_file(buf, &opts, &error);
-		if (error.type == UFBX_ERROR_FILE_NOT_FOUND) continue;
+		ufbx_scene *scene = ufbx_load_file(path, &opts, NULL);
 		ufbxt_assert(scene);
-		any_found = true;
 
 		ufbx_node *cube = ufbx_find_node(scene, "pCube1");
 		ufbxt_assert(cube && cube->mesh);
@@ -484,8 +474,6 @@ UFBXT_TEST(synthetic_broken_cluster_connect)
 
 		ufbx_free_scene(scene);
 	}
-
-	ufbxt_assert(any_found);
 }
 #endif
 

--- a/test/test_skin.h
+++ b/test/test_skin.h
@@ -477,6 +477,25 @@ UFBXT_TEST(synthetic_broken_cluster_connect)
 }
 #endif
 
+UFBXT_TEST(synthetic_broken_cluster_safe)
+#if UFBXT_IMPL
+{
+	char path[512];
+
+	// Same test as above but check that the scene is valid if we don't
+	// pass `connect_broken_elements`.
+	ufbxt_file_iterator iter = { "synthetic_broken_cluster" };
+	while (ufbxt_next_file(&iter, path, sizeof(path))) {
+		ufbx_load_opts opts = { 0 };
+		ufbx_scene *scene = ufbx_load_file(path, &opts, NULL);
+		ufbxt_assert(scene);
+		ufbxt_check_scene(scene);
+
+		ufbx_free_scene(scene);
+	}
+}
+#endif
+
 UFBXT_FILE_TEST(max_transformed_skin)
 #if UFBXT_IMPL
 {

--- a/test/test_transform.h
+++ b/test/test_transform.h
@@ -94,20 +94,12 @@ UFBXT_FILE_TEST(maya_cube_hidden)
 UFBXT_TEST(root_transform)
 #if UFBXT_IMPL
 {
-	const char *name = "maya_cube";
-	char buf[512];
 
 	ufbxt_diff_error err = { 0 };
-	bool any_found = false;
 
-	for (uint32_t vi = 0; vi < ufbxt_arraycount(ufbxt_file_versions); vi++) {
-		for (uint32_t fi = 0; fi < 2; fi++) {
-			uint32_t version = ufbxt_file_versions[vi];
-			const char *format = fi == 1 ? "ascii" : "binary";
-			snprintf(buf, sizeof(buf), "%s%s_%u_%s.fbx", data_root, name, version, format);
-		}
-
-		ufbx_error error;
+	char path[512];
+	ufbxt_file_iterator iter = { "maya_cube" };
+	while (ufbxt_next_file(&iter, path, sizeof(path))) {
 		ufbx_load_opts opts = { 0 };
 
 		ufbx_vec3 euler = { { 90.0f, 0.0f, 0.0f } };
@@ -121,10 +113,8 @@ UFBXT_TEST(root_transform)
 		opts.root_transform.scale.y = 3.0f;
 		opts.root_transform.scale.z = 4.0f;
 
-		ufbx_scene *scene = ufbx_load_file(buf, &opts, &error);
-		if (error.type == UFBX_ERROR_FILE_NOT_FOUND) continue;
+		ufbx_scene *scene = ufbx_load_file(path, &opts, NULL);
 		ufbxt_assert(scene);
-		any_found = true;
 
 		ufbxt_check_scene(scene);
 
@@ -148,15 +138,16 @@ UFBXT_TEST(root_transform)
 		ufbx_free_scene(scene);
 	}
 
+	ufbxt_assert(iter.num_found >= 8);
+
 	ufbxt_logf(".. Absolute diff: avg %.3g, max %.3g (%zu tests)", err.sum / (ufbx_real)err.num, err.max, err.num);
-	ufbxt_assert(any_found);
 }
 #endif
 
 UFBXT_TEST(blender_axes)
 #if UFBXT_IMPL
 {
-	char buf[512];
+	char path[512], name[512];
 
 	ufbxt_diff_error err = { 0 };
 
@@ -173,94 +164,83 @@ UFBXT_TEST(blender_axes)
 			ufbx_coordinate_axis axis_fwd = (ufbx_coordinate_axis)fwd_ix;
 			ufbx_coordinate_axis axis_up = (ufbx_coordinate_axis)up_ix;
 
-			bool any_found = false;
+			snprintf(name, sizeof(name), "blender_axes/axes_%s%s", axis_names[fwd_ix], axis_names[up_ix]);
 
-			for (uint32_t vi = 0; vi < ufbxt_arraycount(ufbxt_file_versions); vi++) {
-				for (uint32_t fi = 0; fi < 2; fi++) {
-					uint32_t version = ufbxt_file_versions[vi];
-					const char *format = fi == 1 ? "ascii" : "binary";
+			ufbxt_file_iterator iter = { name };
+			while (ufbxt_next_file(&iter, path, sizeof(path))) {
 
-					snprintf(buf, sizeof(buf), "%sblender_axes/axes_%s%s_%u_%s.fbx", data_root,
-						axis_names[fwd_ix], axis_names[up_ix], version, format);
+				// Load normally and check axes
+				{
+					ufbx_scene *scene = ufbx_load_file(path, NULL, NULL);
+					ufbxt_assert(scene);
+					ufbxt_check_scene(scene);
 
-					// Load normally and check axes
-					{
-						ufbx_error error;
+					ufbx_coordinate_axis axis_front = axis_fwd ^ 1;
 
-						ufbx_scene *scene = ufbx_load_file(buf, NULL, &error);
-						if (error.type == UFBX_ERROR_FILE_NOT_FOUND) continue;
-						ufbxt_assert(scene);
-						any_found = true;
+					ufbxt_assert(scene->settings.axes.front == axis_front);
+					ufbxt_assert(scene->settings.axes.up == axis_up);
 
-						ufbx_coordinate_axis axis_front = axis_fwd ^ 1;
+					ufbx_free_scene(scene);
+				}
 
-						ufbxt_assert(scene->settings.axes.front == axis_front);
-						ufbxt_assert(scene->settings.axes.up == axis_up);
+				// Axis conversion
+				for (int transform_root = 0; transform_root <= 1; transform_root++) {
+					ufbx_load_opts opts = { 0 };
 
-						ufbx_free_scene(scene);
+					opts.target_axes = ufbx_axes_right_handed_z_up;
+					opts.target_unit_meters = 1.0f;
+
+					if (transform_root) {
+						opts.use_root_transform = true;
+						opts.root_transform = ufbx_identity_transform;
+						opts.root_transform.translation.z = 1.0f;
 					}
 
-					// Axis conversion
-					for (int transform_root = 0; transform_root <= 1; transform_root++) {
-						ufbx_load_opts opts = { 0 };
+					ufbx_scene *scene = ufbx_load_file(path, &opts, NULL);
+					ufbxt_assert(scene);
+					ufbxt_check_scene(scene);
 
-						opts.target_axes = ufbx_axes_right_handed_z_up;
-						opts.target_unit_meters = 1.0f;
+					ufbx_node *plane = ufbx_find_node(scene, "Plane");
+					ufbxt_assert(plane && plane->mesh);
+					ufbx_mesh *mesh = plane->mesh;
+
+					ufbxt_assert(mesh->num_faces == 1);
+					ufbx_face face = mesh->faces[0];
+					ufbxt_assert(face.num_indices == 3);
+
+					for (uint32_t i = 0; i < face.num_indices; i++) {
+						ufbx_vec3 pos = ufbx_get_vertex_vec3(&mesh->vertex_position, face.index_begin + i);
+						ufbx_vec2 uv = ufbx_get_vertex_vec2(&mesh->vertex_uv, face.index_begin + i);
+
+						pos = ufbx_transform_position(&plane->geometry_to_world, pos);
+
+						ufbx_vec3 ref;
+						if (uv.x < 0.5f && uv.y < 0.5f) {
+							ref.x = 1.0f;
+							ref.y = 1.0f;
+							ref.z = 3.0f;
+						} else if (uv.x > 0.5f && uv.y < 0.5f) {
+							ref.x = 2.0f;
+							ref.y = 2.0f;
+							ref.z = 3.0f;
+						} else if (uv.x < 0.5f && uv.y > 0.5f) {
+							ref.x = 1.0f;
+							ref.y = 2.0f;
+							ref.z = 4.0f;
+						} else {
+							ufbxt_assert(0 && "Shouldn't exist");
+						}
 
 						if (transform_root) {
-							opts.use_root_transform = true;
-							opts.root_transform = ufbx_identity_transform;
-							opts.root_transform.translation.z = 1.0f;
+							ref.z += 1.0f;
 						}
 
-						ufbx_scene *scene = ufbx_load_file(buf, &opts, NULL);
-						ufbxt_assert(scene);
-						any_found = true;
-
-						ufbx_node *plane = ufbx_find_node(scene, "Plane");
-						ufbxt_assert(plane && plane->mesh);
-						ufbx_mesh *mesh = plane->mesh;
-
-						ufbxt_assert(mesh->num_faces == 1);
-						ufbx_face face = mesh->faces[0];
-						ufbxt_assert(face.num_indices == 3);
-
-						for (uint32_t i = 0; i < face.num_indices; i++) {
-							ufbx_vec3 pos = ufbx_get_vertex_vec3(&mesh->vertex_position, face.index_begin + i);
-							ufbx_vec2 uv = ufbx_get_vertex_vec2(&mesh->vertex_uv, face.index_begin + i);
-
-							pos = ufbx_transform_position(&plane->geometry_to_world, pos);
-
-							ufbx_vec3 ref;
-							if (uv.x < 0.5f && uv.y < 0.5f) {
-								ref.x = 1.0f;
-								ref.y = 1.0f;
-								ref.z = 3.0f;
-							} else if (uv.x > 0.5f && uv.y < 0.5f) {
-								ref.x = 2.0f;
-								ref.y = 2.0f;
-								ref.z = 3.0f;
-							} else if (uv.x < 0.5f && uv.y > 0.5f) {
-								ref.x = 1.0f;
-								ref.y = 2.0f;
-								ref.z = 4.0f;
-							} else {
-								ufbxt_assert(0 && "Shouldn't exist");
-							}
-
-							if (transform_root) {
-								ref.z += 1.0f;
-							}
-
-							ufbxt_assert_close_vec3(&err, pos, ref);
-						}
-
-						ufbx_free_scene(scene);
+						ufbxt_assert_close_vec3(&err, pos, ref);
 					}
+
+					ufbx_free_scene(scene);
 				}
 			}
-
-			ufbxt_assert(any_found);
 		}
 	}
 


### PR DESCRIPTION
Bonus: Many of the manual iterations were broken on copy-paste.