### PR TITLE
Fix `face_indices.count`

### DIFF
--- a/test/check_scene.h
+++ b/test/check_scene.h
@@ -441,6 +441,7 @@ static void ufbxt_check_mesh(ufbx_scene *scene, ufbx_mesh *mesh)
 		ufbx_mesh_material *mat = &mesh->materials.data[i];
 		ufbxt_check_element_ptr(scene, mat->material, UFBX_ELEMENT_MATERIAL);
 
+		ufbxt_assert(mat->face_indices.count == mat->num_faces);
 		for (size_t j = 0; j < mat->num_faces; j++) {
 			ufbxt_assert(mesh->face_material.data[mat->face_indices.data[j]] == (int32_t)i);
 		}

--- a/ufbx.c
+++ b/ufbx.c
@@ -14145,6 +14145,7 @@ ufbxi_nodiscard ufbxi_noinline static int ufbxi_finalize_scene(ufbxi_context *uc
 				// Allocate per-material buffers (clear `num_faces` to 0 to re-use it as
 				// an index when fetching the face indices).
 				ufbxi_for_list(ufbx_mesh_material, mat, mesh->materials) {
+					mat->face_indices.count = mat->num_faces;
 					mat->face_indices.data = ufbxi_push(&uc->result, uint32_t, mat->num_faces);
 					ufbxi_check(mat->face_indices.data);
 					mat->num_faces = 0;
@@ -18126,6 +18127,7 @@ ufbxi_nodiscard static ufbxi_noinline int ufbxi_finalize_mesh(ufbxi_buf *buf, uf
 
 	// See `ufbxi_finalize_scene()`
 	ufbxi_for_list(ufbx_mesh_material, mat, mesh->materials) {
+		mat->face_indices.count = mat->num_faces;
 		mat->face_indices.data = ufbxi_push(buf, uint32_t, mat->num_faces);
 		ufbxi_check_err(error, mat->face_indices.data);
 		mat->num_faces = 0;


### PR DESCRIPTION
Hotfix for `ufbx_mesh_material.face_indices.count` being not set.